### PR TITLE
Fixed workflows

### DIFF
--- a/.github/workflows/generate-publish-docs.yml
+++ b/.github/workflows/generate-publish-docs.yml
@@ -2,6 +2,7 @@ name: Generate and publish docs
 
 on:
   push:
+    branches: ["main"]
   pull_request:
 
 jobs:

--- a/.github/workflows/generate-publish-docs.yml
+++ b/.github/workflows/generate-publish-docs.yml
@@ -2,7 +2,6 @@ name: Generate and publish docs
 
 on:
   push:
-    branches: [ "main" ]
   pull_request:
 
 jobs:
@@ -54,6 +53,13 @@ jobs:
           cat build/generated/openapi.json | jq '{openapi: "3.0.1", info: .info, servers: .servers, paths: .paths, components: .components}' > temp.json
           mv temp.json build/generated/openapi.json
 
+      - name: Convert OpenAPI spec
+        uses: Legion2/swagger-ui-action@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          output: gh-pages/swagger
+          spec-file: build/generated/openapi.json
+
       - name: Upload Docs Artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -71,13 +77,6 @@ jobs:
         with:
           name: docs
           path: gh-pages
-
-      - name: Convert OpenAPI spec
-        uses: Legion2/swagger-ui-action@v1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          output: gh-pages/swagger
-          spec-file: gh-pages/generated/openapi.json
 
       - name: Create index.html for GitHub Pages
         run: echo '<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=swagger/index.html"></head><body></body></html>' > gh-pages/index.html

--- a/src/main/java/org/example/crmedu/application/controller/package-info.java
+++ b/src/main/java/org/example/crmedu/application/controller/package-info.java
@@ -4,7 +4,7 @@
  * The {@code AdviceController} class provides handlers for exceptions that may arise in the system. These exceptions can occur while working with data at the
  * persistence or business layer, as well as during validation at the transport layer.
  * </p>
- * Other classes, such as {@code OrganizationController}, {@code SubjectController}, {@code TutorController}, {@code TutorScheduleController}, and
+ * Other classes, such as {@code OrganizationController}, {@code SubjectController}, {@code TutorController}, {@code TutorScheduleController}, {@code StudentController} and
  * {@code UserController}, provide RESTful endpoints for data management.
  */
 package org.example.crmedu.application.controller;


### PR DESCRIPTION
In previous version the "Publish docs" workflow worked before "Generate docs", what caused an exception. So, they were merged into one worklflow in separate jobs. Now "publish docs" works only after "Generate Docs" and only on pushing to main.